### PR TITLE
implement serialization feature-flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,14 @@ maintenance = { status = "experimental" }
 is-it-maintained-issue-resolution = { repository = "fubarnetes/rctl" }
 is-it-maintained-open-issues = { repository = "fubarnetes/rctl" }
 
+[features]
+serialize = ["serde", "serde_json"]
+
 [dependencies]
 failure = "0.1"
 libc = "0.2"
 nix = "0.13"
 number_prefix = "0.2"
 sysctl = "0.3"
+serde = { version="1.0", features = ["derive"], optional=true }
+serde_json = { version="1.0", optional=true }

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -1,0 +1,23 @@
+extern crate libc;
+extern crate rctl;
+
+#[cfg(feature="serialize")]
+extern crate serde_json;
+
+#[cfg(feature="serialize")]
+fn main() {
+
+    let uid = unsafe { libc::getuid() };
+
+    let subject = rctl::Subject::user_id(uid);
+
+    let serialized = serde_json::to_string(&subject)
+        .expect("Could not serialize RCTL subject.");
+
+    println!("{}", serialized);
+}
+
+#[cfg(not(feature="serialize"))]
+fn main() {
+   println!("Run `cargo build --features=serialize` to enable this example");
+}


### PR DESCRIPTION
This enables serialization for the following rctl structs:
* User
* Process
* Jail
* LoginClass

and these enums:

* Subject
* SubjectType
* Resource
* Action

It's implemented as a feature and can be enabled with
```
$ cargo build --features=serialize
```