### PR TITLE
Revert "users: drop the users crate"; update users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## [Unreleased] - ReleaseDate
 ### Changed
-- Dropped the `users` crate and fixed erroneous user lookups
-  ([Issue](https://github.com/fubarnetes/rctl/pull/5),
-  [PR](https://github.com/fubarnetes/rctl/pull/5))
+- Updated the Users crate (#1, #7)
 
 ## [0.0.5] - 2018-12-20
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ number_prefix = "0.2"
 sysctl = "0.3"
 serde = { version="1.0", features = ["derive"], optional=true }
 serde_json = { version="1.0", optional=true }
+users = "0.9.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Fabian Freyer <fabian.freyer@physik.tu-berlin.de>
+// Copyright 2019 Fabian Freyer <fabian.freyer@physik.tu-berlin.de>
 // Copyright 2018 David O'Rourke <david.orourke@gmail.com>
 //
 // Redistribution and use in source and binary forms, with or without
@@ -149,7 +149,7 @@ mod subject {
     impl fmt::Display for User {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             match get_user_by_uid(self.0) {
-                Some(user) => write!(f, "user:{}", user.name()),
+                Some(user) => write!(f, "user:{}", user.name().to_str().ok_or(fmt::Error)?),
                 None => write!(f, "user:{}", self.0),
             }
         }


### PR DESCRIPTION
This reverts commit 24a017c375e4072949bc812f63063f0ae9b18b09.

Since https://github.com/ogham/rust-users/issues/34, we can use the
Users crate again, as this resolves #5.

Additionally, update the users crate to v0.9.1.

Closes #7.