### PR TITLE
repeat description from Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # rctl
 
+FreeBSD resource limits and accounting with RCTL / RACCT
+
 [![Build Status](https://api.cirrus-ci.com/github/fubarnetes/rctl.svg)](https://cirrus-ci.com/github/fubarnetes/rctl)
 [![Code Coverage](https://img.shields.io/codecov/c/github/fubarnetes/rctl.svg?logo=codecov&style=flat-square)](https://codecov.io/gh/fubarnetes/rctl)
 [![Crates.io](https://img.shields.io/crates/v/rctl.svg?style=flat-square)](https://crates.io/crates/rctl)


### PR DESCRIPTION
once crates.io loads the readme, the description from Cargo.toml goes away, and you're left guessing what this crate does