### PR TITLE
Update to 2021 edition, bump crate versions, fix issues

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         box:
-          - fbsd_13_0
-          - fbsd_12_2
+          - fbsd_13_1
+          - fbsd_12_4
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         box:
-          - fbsd_13_0
+          - fbsd_13_1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         box:
-          - fbsd_13_0
+          - fbsd_13_1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         box:
-          - fbsd_13_0
-          - fbsd_12_2
+          - fbsd_13_1
+          - fbsd_12_4
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## [Unreleased] - ReleaseDate
+### Changed
+- Updated CI to use latest supported FreeBSD versions (#48)
+- Updated the nix crate (#48)
+- Updated the sysctl crate (#48)
+- Updated all dependencies (#48)
+- Update to the 2021 edition (#48)
+
 
 ## [0.2.0] - 2021-09-25
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["os:unix-apis", "api-bindings"]
 readme = "README.md"
 repository = "https://github.com/fubarnetes/rctl"
 documentation = "https://fubarnetes.github.io/rctl/rctl/"
-edition = "2018"
+edition = "2021"
 
 [badges]
 maintenance = { status = "experimental" }
@@ -21,9 +21,9 @@ serialize = ["serde", "serde_json"]
 
 [dependencies]
 libc = "0.2"
-nix = "0.22"
+nix = "0.26"
 number_prefix = "0.4"
-sysctl = "0.4"
+sysctl = "0.5"
 serde = { version="1.0", features = ["derive"], optional=true }
 serde_json = { version="1.0", optional=true }
 thiserror = "1.0"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,12 +2,12 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.define "fbsd_13_0" do |fbsd_13_0|
-    fbsd_13_0.vm.box = "freebsd/FreeBSD-13.0-RELEASE"
+  config.vm.define "fbsd_13_1" do |fbsd_13_1|
+    fbsd_13_1.vm.box = "freebsd/FreeBSD-13.1-RELEASE"
   end
 
-  config.vm.define "fbsd_12_2" do |fbsd_12_2|
-    fbsd_12_2.vm.box = "freebsd/FreeBSD-12.2-STABLE"
+  config.vm.define "fbsd_12_4" do |fbsd_12_4|
+    fbsd_12_4.vm.box = "freebsd/FreeBSD-12.4-STABLE"
   end
 
   config.vm.synced_folder ".", "/vagrant", type: "rsync",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -790,6 +790,7 @@ impl Action {
                 Signal::SIGSYS => "sigsys",
                 Signal::SIGEMT => "sigemt",
                 Signal::SIGINFO => "siginfo",
+                _ => "unknown",
             },
         }
     }


### PR DESCRIPTION
This PR:
  - Bumps the crate to the 2021 edition
  - Updates all crates to their latest versions
  - Fixes an issue with the new `nix` where the `Signal` enum was marked `non_exhaustive`
  - Updates the Vagrant boxes to the latest supported FreeBSD versions
  - Updated CHANGELOG entries