### PR TITLE
Eliminate dependency on the unmaintained "users" crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,9 @@ serialize = ["serde", "serde_json"]
 
 [dependencies]
 libc = "0.2"
-nix = { version = "0.28", default-features = false, features = [ "signal" ] }
+nix = { version = "0.28", default-features = false, features = [ "signal", "user" ] }
 number_prefix = "0.4"
 sysctl = "0.5"
 serde = { version="1.0", features = ["derive"], optional=true }
 serde_json = { version="1.0", optional=true }
 thiserror = "1.0"
-users = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serialize = ["serde", "serde_json"]
 
 [dependencies]
 libc = "0.2"
-nix = "0.26"
+nix = { version = "0.28", default-features = false, features = [ "signal" ] }
 number_prefix = "0.4"
 sysctl = "0.5"
 serde = { version="1.0", features = ["derive"], optional=true }


### PR DESCRIPTION
Use Nix's "user" feature instead, since we're already using Nix.
    
Fixes #50
