### PR TITLE
Update Nix dependency to 0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased] - ReleaseDate
 ### Changed
 - Updated CI to use latest supported FreeBSD versions (#48)
-- Updated the nix crate (#48)
+- Updated the nix crate (#64)
 - Updated the sysctl crate (#48)
 - Updated all dependencies (#48)
 - Update to the 2021 edition (#48)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ targets = [
 serialize = ["serde", "serde_json"]
 
 [dependencies]
-libc = "0.2.153"
-nix = { version = "0.28", default-features = false, features = [ "signal", "user" ] }
+libc = "0.2.155"
+nix = { version = "0.29", default-features = false, features = [ "signal", "user" ] }
 number_prefix = "0.4"
 sysctl = "0.5"
 serde = { version="1.0.113", features = ["derive"], optional=true }


### PR DESCRIPTION
Because a major downstream consumer uses that version.