### PR TITLE
Expand sysctl version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serialize = ["serde", "serde_json"]
 libc = "0.2.155"
 nix = { version = "0.29", default-features = false, features = [ "signal", "user" ] }
 number_prefix = "0.4"
-sysctl = "0.5"
+sysctl = ">=0.5.0, < 0.7"
 serde = { version="1.0.113", features = ["derive"], optional=true }
 serde_json = { version="1.0", optional=true }
 thiserror = "1.0.32"


### PR DESCRIPTION
sysctl version 0.6.0 is actually compatible with 0.5.0.  Allow consumers to use either.