### PR TITLE
Broaden the dependency spec on Nix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] - ReleaseDate
+
+### Changed
+- Broadened the dependency spec on Nix, for better compatibility with
+  downstream consumers that have various requirements. (#80)
+
 ## [0.3.0] - 2024-10-01
 ### Changed
 - Updated CI to use latest supported FreeBSD versions (#48)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serialize = ["serde", "serde_json"]
 
 [dependencies]
 libc = "0.2.155"
-nix = { version = "0.29", default-features = false, features = [ "signal", "user" ] }
+nix = { version = ">=0.28.0, <0.31", default-features = false, features = [ "signal", "user" ] }
 number_prefix = "0.4"
 sysctl = ">=0.5.0, < 0.7"
 serde = { version="1.0.113", features = ["derive"], optional=true }


### PR DESCRIPTION
For better compatibility with downstream consumers that have various requirements.